### PR TITLE
feat: update experience with Director promotion and 2025 accomplishments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Dan Haight's professional portfolio site showcasing Analytics Leadership experie
 
 **Domain:** danalytics.info
 **Repository:** github.com/haighd/portfolio
+**LinkedIn:** linkedin.com/in/djhaight
 
 ---
 

--- a/src/content/experience/bd-analytics.mdx
+++ b/src/content/experience/bd-analytics.mdx
@@ -4,7 +4,7 @@ role: "Associate Director, Supply Chain Analytics"
 startDate: "Nov 2020"
 endDate: "May 2023"
 location: "Franklin Lakes, NJ"
-order: 2
+order: 3
 ---
 
 - Developed Linear Programming Optimization automating product allocation for short-supply products, improving consistency and reducing manual labor

--- a/src/content/experience/bd-transportation.mdx
+++ b/src/content/experience/bd-transportation.mdx
@@ -4,7 +4,7 @@ role: "Senior Manager, NA Supply Chain, Transportation CI"
 startDate: "Nov 2019"
 endDate: "Nov 2020"
 location: "Franklin Lakes, NJ"
-order: 3
+order: 4
 ---
 
 - Coached Project Leaders in delivering >$4.1M savings YTD, exceeding $5M annual target

--- a/src/content/experience/merck-assoc-director.mdx
+++ b/src/content/experience/merck-assoc-director.mdx
@@ -1,0 +1,13 @@
+---
+company: "Merck & Co."
+role: "Associate Director, Data Science"
+startDate: "May 2023"
+endDate: "Nov 2024"
+location: "Rahway, NJ"
+order: 2
+---
+
+- Led team of 12, completing 60+ projects delivering value across 6 therapy areas (HIV, COVID, ABX, CMV)
+- Coached 2 direct reports on career development, identifying promotional opportunities and strengthening skillsets
+- Designed and deployed Jira board for Commercial Analytics Data Science Pharma, standardizing workflows and optimizing resource utilization
+- Implemented technical SOPs for code version control, code review, and document storage

--- a/src/content/experience/merck.mdx
+++ b/src/content/experience/merck.mdx
@@ -1,12 +1,15 @@
 ---
 company: "Merck & Co."
-role: "Associate Director, Data Science"
-startDate: "May 2023"
+role: "Director, Data Science"
+startDate: "Nov 2024"
 location: "Rahway, NJ"
 order: 1
 ---
 
-- Lead team of 12, completing 60+ projects delivering value across 6 therapy areas (HIV, COVID, ABX, CMV)
-- Coach 2 direct reports on career development, identifying promotional opportunities and strengthening skillsets
-- Designed and deployed Jira board for Commercial Analytics Data Science Pharma, standardizing workflows and optimizing resource utilization
-- Implemented technical SOPs for code version control, code review, and document storage
+- Designed and delivered multiple complex data models, dashboards, and a full-stack application converting raw clinical operations data into actionable insights for Continuous Improvement projects
+- Developed and implemented 8 data models tracking compliance of Monitoring Excellence activities (site initiation visits, site validation visits, source document review, clinical supplies monitoring, on-site monitoring frequency) and Clinical Supplies Chain-of-Custody requirements
+- Advanced team standard work by deploying documentation templates, Power BI dashboard templates, and co-creating cross-team workflows between CILs and CIAs with the CI Quality Lead
+- Facilitated cross-functional collaboration to establish shared templates and workflows; acted as integrator for the Continuous Improvement Team to remove blockers and coordinate dependencies
+- Partnered with direct reports to build Career Blueprints, define development goals, and set concrete action plans with regular coaching and feedback
+- Applied Sigma Green Belt methods to ensure transparent metrics, structured problem solving, and accountable delivery
+- Earned ACRP-CP and Merck Sigma Green Belt certifications

--- a/src/content/experience/unitedhealth.mdx
+++ b/src/content/experience/unitedhealth.mdx
@@ -4,7 +4,7 @@ role: "Assoc. Director, Business Transformation & Process Optimization"
 startDate: "Jul 2018"
 endDate: "Nov 2019"
 location: "Minneapolis, MN"
-order: 4
+order: 5
 ---
 
 - Led team of Six Sigma Black Belts and Project Managers completing 14 projects ($20.1M savings in 2018) and 18 projects ($30.1M value in 2019)


### PR DESCRIPTION
## Summary

- Update Merck role to **Director, Data Science** (Nov 2024 - Present) with 2025 accomplishments
- Add **Associate Director, Data Science** role (May 2023 - Nov 2024) showing promotion path
- Update order numbers for timeline display
- Add LinkedIn profile URL to CLAUDE.md

## Experience Timeline

| Order | Company | Role | Dates |
|-------|---------|------|-------|
| 1 | Merck & Co. | Director, Data Science | Nov 2024 - Present |
| 2 | Merck & Co. | Associate Director, Data Science | May 2023 - Nov 2024 |
| 3 | BD | Associate Director, Supply Chain Analytics | Nov 2020 - May 2023 |
| 4 | BD | Senior Manager, Transportation CI | Nov 2019 - Nov 2020 |
| 5 | UnitedHealth Group | Assoc. Director, Business Transformation | Jul 2018 - Nov 2019 |

## Test plan

- [ ] Run `bun build` - verify Velite processes all 5 experience files
- [ ] Run `bun dev` - check experience page renders all roles
- [ ] Verify timeline displays in correct order (Director first)
- [ ] Verify Merck promotion is visually clear