### PR TITLE
chore: ignore resume PDFs for privacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # velite content layer
 .velite
+
+# resume files (privacy)
+docs/resume/*.pdf


### PR DESCRIPTION
## Summary

- Add `docs/resume/*.pdf` to `.gitignore` to prevent accidental publication of resume files

## Rationale

Resume PDFs should be shared selectively rather than being freely available in the public repository.

## Test plan

- [x] Verify PDF file no longer shows as untracked in `git status`

Closes #23