### PR TITLE
feat: add RSS feed for blog posts

### DIFF
--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,51 @@
+import { getBlogPosts } from "@/lib/content";
+
+const SITE_URL = "https://danalytics.info";
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET() {
+  const posts = getBlogPosts();
+
+  const rssItems = posts
+    .map((post) => {
+      const pubDate = new Date(post.publishedDate).toUTCString();
+      const postUrl = `${SITE_URL}/blog/${post.slug}`;
+
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${postUrl}</link>
+      <guid isPermaLink="true">${postUrl}</guid>
+      <description>${escapeXml(post.description)}</description>
+      <pubDate>${pubDate}</pubDate>
+    </item>`;
+    })
+    .join("\n");
+
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Dan Haight | Blog</title>
+    <link>${SITE_URL}/blog</link>
+    <description>Analytics, data engineering, and technical leadership insights from Dan Haight.</description>
+    <language>en-us</language>
+    <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
+${rssItems}
+  </channel>
+</rss>`;
+
+  return new Response(rss, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "s-maxage=3600, stale-while-revalidate",
+    },
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,6 +41,11 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
+  alternates: {
+    types: {
+      "application/rss+xml": "https://danalytics.info/feed.xml",
+    },
+  },
 };
 
 export default function RootLayout({

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { projects } from "#site/content";
+import { projects, blog } from "#site/content";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://danalytics.info";
@@ -50,5 +50,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }));
 
-  return [...staticPages, ...projectPages];
+  const blogPages: MetadataRoute.Sitemap = blog.map((post) => ({
+    url: `${baseUrl}/blog/${post.slug}`,
+    lastModified: post.updatedDate
+      ? new Date(post.updatedDate)
+      : new Date(post.publishedDate),
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
+
+  return [...staticPages, ...projectPages, ...blogPages];
 }

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Github, Linkedin, Mail } from "lucide-react";
+import { Github, Linkedin, Mail, Rss } from "lucide-react";
 import { Container } from "@/components/ui";
 
 const socialLinks = [
@@ -17,6 +17,11 @@ const socialLinks = [
     name: "Email",
     href: "mailto:dan@danalytics.info",
     icon: Mail,
+  },
+  {
+    name: "RSS Feed",
+    href: "/feed.xml",
+    icon: Rss,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Add `/feed.xml` RSS feed endpoint for blog post subscriptions
- Add RSS autodiscovery `<link>` tag to all pages
- Add RSS icon to footer social links
- Add blog posts to sitemap.xml (bonus fix - they were missing)

## Test plan
- [ ] Visit `/feed.xml` and verify valid RSS 2.0 XML
- [ ] Check page source for `<link rel="alternate" type="application/rss+xml">`
- [ ] Verify RSS icon appears in footer
- [ ] Test feed in an RSS reader (e.g., Feedly)

Closes #9