### PR TITLE
feat: add Now page showing current focus and activities

### DIFF
--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -6,10 +6,12 @@ import { MDXContent } from "@/components/mdx-content";
 import { getNowContent } from "@/lib/content";
 import { formatDate } from "@/lib/utils";
 
+const description =
+  "What I'm currently focused on, learning, reading, and building.";
+
 export const metadata: Metadata = {
   title: "Now",
-  description:
-    "What I'm currently focused on, learning, reading, and building.",
+  description,
 };
 
 export default function NowPage() {
@@ -26,9 +28,7 @@ export default function NowPage() {
           Now
           <span className="mt-2 block h-1 w-16 rounded-full bg-foreground/20" />
         </h1>
-        <p className="mt-4 text-lg text-muted-foreground">
-          What I&apos;m currently focused on, learning, reading, and building.
-        </p>
+        <p className="mt-4 text-lg text-muted-foreground">{description}</p>
         <p className="mt-4 flex items-center gap-2 text-sm text-muted-foreground">
           <Calendar className="h-4 w-4" aria-hidden="true" />
           Last updated{" "}

--- a/src/app/now/page.tsx
+++ b/src/app/now/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Calendar } from "lucide-react";
+import { Section } from "@/components/layout";
+import { MDXContent } from "@/components/mdx-content";
+import { getNowContent } from "@/lib/content";
+import { formatDate } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  title: "Now",
+  description:
+    "What I'm currently focused on, learning, reading, and building.",
+};
+
+export default function NowPage() {
+  const now = getNowContent();
+
+  if (!now) {
+    notFound();
+  }
+
+  return (
+    <Section className="pt-24 md:pt-32" containerSize="narrow">
+      <header className="mb-12">
+        <h1 className="text-4xl font-bold tracking-tight">
+          Now
+          <span className="mt-2 block h-1 w-16 rounded-full bg-foreground/20" />
+        </h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          What I&apos;m currently focused on, learning, reading, and building.
+        </p>
+        <p className="mt-4 flex items-center gap-2 text-sm text-muted-foreground">
+          <Calendar className="h-4 w-4" aria-hidden="true" />
+          Last updated{" "}
+          <time dateTime={now.lastUpdated}>{formatDate(now.lastUpdated)}</time>
+        </p>
+      </header>
+
+      <article>
+        <MDXContent code={now.body} />
+      </article>
+    </Section>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { projects, blog } from "#site/content";
+import { projects, now, blog } from "#site/content";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://danalytics.info";
@@ -19,7 +19,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
     {
       url: `${baseUrl}/now`,
-      lastModified: new Date(),
+      lastModified: now[0] ? new Date(now[0].lastUpdated) : new Date(),
       changeFrequency: "weekly",
       priority: 0.7,
     },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -18,6 +18,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
+      url: `${baseUrl}/now`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/experience`,
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -10,6 +10,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 
 const navigation = [
   { name: "About", href: "/about" },
+  { name: "Now", href: "/now" },
   { name: "Experience", href: "/experience" },
   { name: "Projects", href: "/projects" },
   { name: "Blog", href: "/blog" },

--- a/src/content/now/index.mdx
+++ b/src/content/now/index.mdx
@@ -1,0 +1,27 @@
+---
+title: "Now"
+lastUpdated: "2026-01-30"
+---
+
+## Current Focus
+
+- Leading analytics initiatives and ML/AI solutions at Merck
+- Building full-stack side projects to stay sharp on modern web development
+- Exploring AI-assisted development workflows
+
+## Learning
+
+- Advanced TypeScript patterns and type-level programming
+- LLM application development and prompt engineering
+- System design for scalable data platforms
+
+## Reading
+
+- *Designing Data-Intensive Applications* by Martin Kleppmann
+- Various technical blogs on distributed systems and ML engineering
+
+## Side Projects
+
+- This portfolio site (Next.js, TypeScript, Tailwind)
+- Algorithmic trading systems with Python
+- Experimenting with AI coding assistants

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,7 +1,8 @@
-import { projects, experiences, blog } from "#site/content";
+import { projects, experiences, now, blog } from "#site/content";
 
 export type Project = (typeof projects)[number];
 export type Experience = (typeof experiences)[number];
+export type Now = (typeof now)[number];
 export type BlogPost = (typeof blog)[number];
 
 export function getProjects() {
@@ -20,6 +21,10 @@ export function getProjectBySlug(slug: string) {
 
 export function getExperiences() {
   return experiences.sort((a, b) => a.order - b.order);
+}
+
+export function getNowContent() {
+  return now[0];
 }
 
 export function getBlogPosts() {

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -37,7 +37,7 @@ const now = defineCollection({
   pattern: "now/*.mdx",
   schema: s.object({
     title: s.string(),
-    lastUpdated: s.string(),
+    lastUpdated: s.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be in YYYY-MM-DD format"),
     body: s.mdx(),
   }),
 });

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -32,6 +32,16 @@ const experiences = defineCollection({
   }),
 });
 
+const now = defineCollection({
+  name: "Now",
+  pattern: "now/*.mdx",
+  schema: s.object({
+    title: s.string(),
+    lastUpdated: s.string(),
+    body: s.mdx(),
+  }),
+});
+
 const blog = defineCollection({
   name: "BlogPost",
   pattern: "blog/**/*.mdx",
@@ -65,7 +75,7 @@ export default defineConfig({
     name: "[name]-[hash:6].[ext]",
     clean: true,
   },
-  collections: { projects, experiences, blog },
+  collections: { projects, experiences, now, blog },
   mdx: {
     remarkPlugins: [],
     rehypePlugins: [],


### PR DESCRIPTION
## Summary
- Adds a `/now` page showing current focus, learning, reading, and side projects
- Uses MDX content for easy updates via `src/content/now/index.mdx`
- Adds navigation link in header after "About"
- Displays "Last updated" date from frontmatter

Closes #42

## Test plan
- [ ] Navigate to `/now` and verify page renders
- [ ] Verify navigation link appears and highlights when active
- [ ] Verify "Last updated" date displays correctly
- [ ] Verify MDX content renders with proper styling
- [ ] Run `bun run build` to confirm static generation